### PR TITLE
Remove convert_tz from date_raw fields

### DIFF
--- a/main.view.lkml
+++ b/main.view.lkml
@@ -337,7 +337,6 @@ view: main {
     # use contains a time, then the parameter should be set to yes.
     hidden: yes
     type: date_raw
-    convert_tz: no
     sql:
       {%- if convert_tz._parameter_value == 'true' -%}
         {%- case '@{database_type}' -%}
@@ -378,7 +377,6 @@ view: main {
       {%- when "mysql" -%} curdate()
       {%- endcase -%}
       {%- endif -%};;
-    convert_tz: no
   }
 
   dimension: end_date_dim_as_of_mod {
@@ -411,7 +409,6 @@ view: main {
       {%- endcase %}
 
       {%- endif -%};;
-    convert_tz: no
   }
 
   dimension: end_date_dim {
@@ -420,7 +417,6 @@ view: main {
     #
     # @todo: Will convert_timezone always be needed on the max origin date function?
     type: date_raw
-    convert_tz: no
     hidden:  yes
     sql:{%- if period_selection._parameter_value == 'lw' or period_selection._parameter_value == 'lm'
                or period_selection._parameter_value == 'lq' or period_selection._parameter_value == 'ly' -%}
@@ -643,7 +639,6 @@ view: main {
     #   1. The else case handles trailing selection
     hidden: yes
     type: date_raw
-    convert_tz: no
     sql:
         {%- case period_selection._parameter_value -%}
             {%- when 'wtd' -%}


### PR DESCRIPTION
convert_tz param now throws warnings on date_raw fields in Looker. Since date_raw never gets converted anyway we can safely remove these to clear the warning.